### PR TITLE
feat: Add additional Prometheus metrics for KronosApp schedule information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= kronosorg/kronos-core:v0.2.0
+IMG ?= kronosorg/kronos-core:v0.3.0
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,17 +25,18 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	v1alpha1 "gitlab.infra.wecraft.tn/wecraft/automation/ifra/kronos/api/v1alpha1"
+	kronosapp "gitlab.infra.wecraft.tn/wecraft/automation/ifra/kronos/internal/controller"
+	kronosappController "gitlab.infra.wecraft.tn/wecraft/automation/ifra/kronos/internal/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrlMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
-	v1alpha1 "gitlab.infra.wecraft.tn/wecraft/automation/ifra/kronos/api/v1alpha1"
-	kronosappController "gitlab.infra.wecraft.tn/wecraft/automation/ifra/kronos/internal/controller"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -122,9 +123,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	additionalMetrics := kronosapp.RegisterMetrics("kronos").MustRegister(ctrlMetrics.Registry)
+
 	if err = (&kronosappController.KronosAppReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Metrics: additionalMetrics,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KronosApp")
 		os.Exit(1)

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patches:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: kronosorg/kronos-core
-  newTag: v0.2.0
+  newTag: v0.3.0

--- a/dist/kronos.yaml
+++ b/dist/kronos.yaml
@@ -525,7 +525,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: kronosorg/kronos-core:v0.2.0
+        image: kronosorg/kronos-core:v0.3.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/dist/kronos.yaml
+++ b/dist/kronos.yaml
@@ -555,3 +555,28 @@ spec:
         runAsNonRoot: true
       serviceAccountName: kronos-controller-manager
       terminationGracePeriodSeconds: 10
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: kronos
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/part-of: kronos
+    control-plane: controller-manager
+  name: kronos-controller-manager-metrics-monitor
+  namespace: kronos-system
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/internal/controller/kronosapp_controller.go
+++ b/internal/controller/kronosapp_controller.go
@@ -22,13 +22,13 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"gitlab.infra.wecraft.tn/wecraft/automation/ifra/kronos/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"gitlab.infra.wecraft.tn/wecraft/automation/ifra/kronos/api/v1alpha1"
 )
 
 // KronosAppReconciler reconciles a KronosApp object

--- a/internal/controller/kronosapp_controller.go
+++ b/internal/controller/kronosapp_controller.go
@@ -53,6 +53,7 @@ type KronosAppReconciler struct {
 func (r *KronosAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := log.Log
 	kronosApp, err := r.getKronosApp(ctx, req)
+	MetricsInit()
 	if err != nil {
 		l.Error(err, "Unable to fetch KronosApp")
 		if apierrors.IsNotFound(err) {
@@ -63,6 +64,7 @@ func (r *KronosAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		return ctrl.Result{}, err
 	}
+
 	scheduleInfo.With(prometheus.Labels{
 		"name":      req.Name,
 		"namespace": req.Namespace,

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,25 +1,28 @@
 package kronosapp
 
 import (
-	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var (
-	scheduleInfo = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "schedule_info",
-			Help: "Current schedule information",
-		},
-		[]string{
-			"name",
-			"namespace",
-		},
-	)
-)
+type Metrics struct {
+	ScheduleInfo *prometheus.GaugeVec
+}
 
-func MetricsInit() {
-	fmt.Println("Registering Metric")
-	metrics.Registry.MustRegister(scheduleInfo)
+func RegisterMetrics(prefix string) Metrics {
+	sleepInfoMetrics := Metrics{
+		ScheduleInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: prefix,
+			Name:      "schedule_info",
+			Help:      "Current schedule information",
+		}, []string{"name", "namespace"}),
+	}
+	return sleepInfoMetrics
+}
+
+func (additionalMetrics Metrics) MustRegister(registry metrics.RegistererGatherer) Metrics {
+	registry.MustRegister(
+		additionalMetrics.ScheduleInfo,
+	)
+	return additionalMetrics
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,6 +1,6 @@
 package kronosapp
 
-import(
+import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -12,12 +12,11 @@ var (
 			Help: "Current schedule information",
 		},
 		[]string{
-			"name", 
+			"name",
 			"namespace",
 		},
 	)
 )
-
 
 func init() {
 	metrics.Registry.MustRegister(scheduleInfo)

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,6 +1,7 @@
 package kronosapp
 
 import (
+	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -18,6 +19,7 @@ var (
 	)
 )
 
-func init() {
+func MetricsInit() {
+	fmt.Println("Registering Metric")
 	metrics.Registry.MustRegister(scheduleInfo)
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,24 @@
+package kronosapp
+
+import(
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	scheduleInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "schedule_info",
+			Help: "Current schedule information",
+		},
+		[]string{
+			"name", 
+			"namespace",
+		},
+	)
+)
+
+
+func init() {
+	metrics.Registry.MustRegister(scheduleInfo)
+}

--- a/internal/controller/objects.go
+++ b/internal/controller/objects.go
@@ -12,10 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;update
-
 
 type ObjectList struct {
 	Deployments  *appsv1.DeploymentList


### PR DESCRIPTION
This PR adds new Prometheus metrics to the KronosApp CR to provide more visibility into schedule information. The new metrics allow monitoring tools to track scheduling patterns more effectively. Also, support for Prometheus ServiceMonitor was added.