### PR TITLE
feat: Add support for ReplicaSet Resource

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,7 @@ rules:
   - apps
   resources:
   - deployments
+  - replicasets
   - statefulsets
   verbs:
   - get

--- a/internal/controller/included-objects/object.go
+++ b/internal/controller/included-objects/object.go
@@ -99,6 +99,11 @@ func (o ReplicaResource) UpdateClient(ctx context.Context, Client client.Client)
 		if err != nil {
 			return err
 		}
+	case "ReplicaSet":
+		resource, err = GetReplicaSet(ctx, Client, o)
+		if err != nil {
+			return err
+		}
 	}
 	err = Client.Update(ctx, resource)
 	if err != nil {

--- a/internal/controller/included-objects/replicaset.go
+++ b/internal/controller/included-objects/replicaset.go
@@ -1,0 +1,71 @@
+package object
+
+import (
+	"context"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"regexp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getReplicaSetsByPattern(object Object, allObjects *appsv1.ReplicaSetList) *appsv1.ReplicaSetList {
+	filteredReplicaSets := &appsv1.ReplicaSetList{}
+	if object.IncludeRef == "" {
+		object.IncludeRef = ".*"
+	}
+	if object.ExcludeRef == "" {
+		object.ExcludeRef = "^$"
+	}
+	if object.IncludeRef == "" && object.ExcludeRef == "" {
+		return allObjects
+	}
+	if object.IncludeRef == object.ExcludeRef {
+		return nil
+	}
+
+	includeRe := regexp.MustCompile(object.IncludeRef)
+	excludeRe := regexp.MustCompile(object.ExcludeRef)
+	for _, replicaset := range allObjects.Items {
+		if includeRe.MatchString(replicaset.Name) && !excludeRe.MatchString(replicaset.Name) {
+			filteredReplicaSets.Items = append(filteredReplicaSets.Items, replicaset)
+		}
+	}
+	return filteredReplicaSets
+}
+
+func getAllReplicaSets(ctx context.Context, object Object) (*appsv1.ReplicaSetList, error) {
+	replicasetList := &appsv1.ReplicaSetList{}
+	err := object.Client.List(ctx, replicasetList, client.InNamespace(object.Namespace))
+	if err != nil {
+		return nil, err
+	}
+	return replicasetList, err
+}
+
+func GetReplicaSetListNames(objects *appsv1.ReplicaSetList) []string {
+	var listNames []string
+	for _, objectItem := range objects.Items {
+		listNames = append(listNames, objectItem.Name)
+	}
+	return listNames
+}
+
+func FetchReplicaSets(ctx context.Context, Client client.Client, includeRef, excludeRef, namespace string) (*appsv1.ReplicaSetList, error) {
+	resource := NewObject(Client, includeRef, excludeRef, namespace)
+	allObjects, err := getAllReplicaSets(ctx, resource)
+	if err != nil {
+		return nil, err
+	}
+	filteredObjects := getReplicaSetsByPattern(resource, allObjects)
+	return filteredObjects, nil
+}
+
+func GetReplicaSet(ctx context.Context, Client client.Client, resource ReplicaResource) (*appsv1.ReplicaSet, error) {
+	replicaset := appsv1.ReplicaSet{}
+	err := Client.Get(ctx, types.NamespacedName{Name: resource.ResourceName, Namespace: resource.ResourceNamespace}, &replicaset)
+	if err != nil {
+		return nil, err
+	}
+	replicaset.Spec.Replicas = &resource.ResourceReplicas
+	return &replicaset, nil
+}

--- a/internal/controller/objects.go
+++ b/internal/controller/objects.go
@@ -12,14 +12,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-
-// +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets;replicasets,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;update
-
 
 type ObjectList struct {
 	Deployments  *appsv1.DeploymentList
 	StatefulSets *appsv1.StatefulSetList
+	ReplicaSets  *appsv1.ReplicaSetList
 	CronJobs     *batchv1.CronJobList
 }
 
@@ -34,7 +33,9 @@ func (objectList *ObjectList) GetObjectsNames() map[string][]string {
 	if objectList.CronJobs != nil {
 		objectNames["CronJobs"] = object.GetCronjobListNames(objectList.CronJobs)
 	}
-
+	if objectList.ReplicaSets != nil {
+		objectNames["ReplicaSets"] = object.GetReplicaSetListNames(objectList.ReplicaSets)
+	}
 	return objectNames
 }
 
@@ -49,6 +50,9 @@ func (objectList *ObjectList) GetObjectsCount() map[string]int {
 	if objectList.CronJobs != nil {
 		objectCount["CronJobs"] = len(objectList.CronJobs.Items)
 	}
+	if objectList.ReplicaSets != nil {
+		objectCount["ReplicaSets"] = len(objectList.ReplicaSets.Items)
+	}
 	return objectCount
 }
 
@@ -62,6 +66,9 @@ func (objectList *ObjectList) GetObjectsTotalCount() int {
 	}
 	if objectList.CronJobs != nil {
 		count += len(objectList.CronJobs.Items)
+	}
+	if objectList.ReplicaSets != nil {
+		count += len(objectList.ReplicaSets.Items)
 	}
 	return count
 }
@@ -116,7 +123,7 @@ func (m *APIVersionKindMap) KindExists(kind string) bool {
 
 func getSupportedObjectsApiVersionAndKind() *APIVersionKindMap {
 	kindToAPIVersion := NewAPIVersionKindMap(map[string][]string{
-		"apps/v1":  {"Deployment", "StatefulSet"},
+		"apps/v1":  {"Deployment", "StatefulSet", "ReplicaSet"},
 		"batch/v1": {"CronJob"},
 	})
 	return kindToAPIVersion
@@ -201,6 +208,13 @@ func FetchAndFilter(ctx context.Context, Client client.Client, objectList *Objec
 			if len(cronjobs.Items) > 0 {
 				objectList.CronJobs = cronjobs
 			}
+			replicasets, err := object.FetchReplicaSets(ctx, Client, includeRef, excludeRef, namespace)
+			if err != nil {
+				return err
+			}
+			if len(replicasets.Items) > 0 {
+				objectList.ReplicaSets = replicasets
+			}
 		}
 	case "apps/v1":
 		switch kind {
@@ -224,6 +238,16 @@ func FetchAndFilter(ctx context.Context, Client client.Client, objectList *Objec
 					objectList.StatefulSets = statefulsets
 				}
 			}
+		case "ReplicaSet":
+			{
+				replicasets, err := object.FetchReplicaSets(ctx, Client, includeRef, excludeRef, namespace)
+				if err != nil {
+					return err
+				}
+				if len(replicasets.Items) > 0 {
+					objectList.ReplicaSets = replicasets
+				}
+			}
 		case "*":
 			{
 				deployments, err := object.FetchDeployments(ctx, Client, includeRef, excludeRef, namespace)
@@ -239,6 +263,13 @@ func FetchAndFilter(ctx context.Context, Client client.Client, objectList *Objec
 				}
 				if len(statefulsets.Items) > 0 {
 					objectList.StatefulSets = statefulsets
+				}
+				replicasets, err := object.FetchReplicaSets(ctx, Client, includeRef, excludeRef, namespace)
+				if err != nil {
+					return err
+				}
+				if len(replicasets.Items) > 0 {
+					objectList.ReplicaSets = replicasets
 				}
 			}
 		}
@@ -456,7 +487,47 @@ func putIncludedObjectsToSleep(ctx context.Context, Client client.Client, secret
 			return nil, err
 		}
 	}
+	if includedObjects.ReplicaSets != nil {
+		var savedResources []object.ResourceInt
+		var sleptResourcesToSave []object.ResourceInt
+		dataExists := CheckIfSecretContainsDataOfKind(secret, "ReplicaSet")
+		if dataExists {
+			savedResources, err = getSecretDatas(secret, "ReplicaSet")
+			if err != nil {
+				return nil, err
+			}
+		}
+		for _, item := range includedObjects.ReplicaSets.Items {
+			objectExists := false
+			index := 0
+			if len(savedResources) != 0 {
+				index, objectExists = checkOccurenceInSavedData(savedResources, item.Name, item.Namespace)
+			}
 
+			if !objectExists {
+				replicaset := object.NewReplicaResource(item.Kind, item.Name, item.Namespace, *item.Spec.Replicas)
+				replicaset.AddToList(replicaResourceMap)
+				replicaset.PutToSleep(ctx, Client)
+			} else {
+				sleptResourcesToSave = append(sleptResourcesToSave, savedResources[index])
+				savedResources = removeElementFromArray(savedResources, index)
+			}
+		}
+
+		if len(savedResources) != 0 {
+			for _, resource := range savedResources {
+				resource.Wake(ctx, Client)
+			}
+		}
+
+		replicasetList := object.CastReplicaToGeneral(replicaResourceMap.Items["ReplicaSet"])
+		replicasetList = append(replicasetList, sleptResourcesToSave...)
+
+		err = WriteChanges(ctx, Client, secret, replicasetList, "ReplicaSet", failedObjects, failedObjectsSleepActions)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return failedObjectsSleepActions, nil
 }
 

--- a/internal/controller/secrets.go
+++ b/internal/controller/secrets.go
@@ -140,7 +140,7 @@ func getSecretDatas(secret *corev1.Secret, kind string) ([]object.ResourceInt, e
 	var resourceList []object.ResourceInt
 	var err error
 	switch kind {
-	case "Deployment", "StatefulSet":
+	case "Deployment", "StatefulSet", "ReplicaSet":
 		{
 			var jsonData = []object.ReplicaResource{}
 			if secret.Data[kind] != nil {


### PR DESCRIPTION
This PR extends the KronosApp CR to support scheduling ReplicaSet resources. It introduces new fields in the CRD spec to define ReplicaSet scheduling rules, allowing users to specify how and when ReplicaSets should be created and managed by the Kronos controller.