### PR TITLE
fix: changed prefixing metrics approach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= kronosorg/kronos-core:v0.3.0
+IMG ?= kronosorg/kronos-core:v0.3.1
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,7 +122,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	additionalMetrics := kronosappController.RegisterMetrics("kronos").MustRegister(ctrlMetrics.Registry)
+	additionalMetrics := kronosappController.RegisterMetrics("").MustRegister(ctrlMetrics.Registry)
 
 	if err = (&kronosappController.KronosAppReconciler{
 		Client:  mgr.GetClient(),

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: kronosorg/kronos-core
-  newTag: v0.3.0
+  newTag: v0.3.1

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -20,6 +20,13 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         insecureSkipVerify: true
+      metricRelabelings:
+        - action: replace
+          regex: (.*)
+          replacement: kronos_$1
+          sourceLabels:
+          - __name__
+          targetLabel: __name__
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/dist/kronos.yaml
+++ b/dist/kronos.yaml
@@ -419,7 +419,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: kronosorg/kronos-core:v0.3.0
+        image: kronosorg/kronos-core:v0.3.1
         livenessProbe:
           httpGet:
             path: /healthz
@@ -466,6 +466,13 @@ metadata:
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    metricRelabelings:
+    - action: replace
+      regex: (.*)
+      replacement: kronos_$1
+      sourceLabels:
+      - __name__
+      targetLabel: __name__
     path: /metrics
     port: https
     scheme: https


### PR DESCRIPTION
This change involves moving the responsibility of metric prefixing from within the controller to the metric scraping jobs. Previously, the controller was responsible for adding prefixes to the metrics exposed by the Kronos controller.